### PR TITLE
Handle interaction with selfBrowserSurface

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,14 +83,13 @@
               newly [=exception/created=] {{TypeError}}.
             </li>
             <li>
-              All other steps associated with
+              The rest of the
               <a href="https://www.w3.org/TR/screen-capture/#dom-mediadevices-getdisplaymedia"
                 >getDisplayMedia algorithm</a
               >
-              should now be applied. If these steps culminate in the user agent presenting the user
-              with a selection of
-              <a data-cite="SCREEN-CAPTURE#dfn-display-surface">display surfaces</a>, the user agent
-              SHOULD present the current tab as the most prominent option.
+              should now be executed, with one change - if the algorithm's execution reaches the
+              step where the user agent asks the user to choose a display surface to capture, then
+              the user agent SHOULD present the current tab as the most prominent option.
             </li>
           </ol>
         </dd>

--- a/index.html
+++ b/index.html
@@ -79,9 +79,8 @@
             </li>
             <li>
               If <code>constraints.</code>{{DisplayMediaStreamOptions/selfBrowserSurface}} is
-              {{SelfCapturePreferenceEnum/"exclude"}}, return a promise <a>rejected</a>
-              with a {{DOMException}} object whose {{DOMException/name}} attribute has the value
-              {{InvalidStateError}}.
+              {{SelfCapturePreferenceEnum/"exclude"}}, return a promise [=reject|rejected=] with a
+              newly [=exception/created=] {{TypeError}}.
             </li>
             <li>
               All other steps associated with {{MediaDevices/getDisplayMedia()}} should now be

--- a/index.html
+++ b/index.html
@@ -81,10 +81,11 @@
               with a {{DOMException}} object whose {{DOMException/name}} attribute has the value
               {{InvalidStateError}}.
             </li>
-            <li>The user agent SHOULD present the current tab as the most prominent option.</li>
             <li>
               All other steps associated with {{MediaDevices/getDisplayMedia()}} should now be
-              applied.
+              applied. If these steps culminate in the user agent presenting the user with a
+              selection of display surfaces, the user agent SHOULD present the current tab as the
+              most prominent option.
             </li>
           </ol>
         </dd>

--- a/index.html
+++ b/index.html
@@ -73,7 +73,9 @@
               <p>Let <var>constraints</var> be the method's first argument.</p>
             </li>
             <li>
-              If <code>constraints.preferCurrentTab</code> is <code>false</code>, abort these steps.
+              If <code>constraints.preferCurrentTab</code> is <code>false</code>, abort these steps
+              and continue instead with the usual set of steps associated
+              {{MediaDevices/getDisplayMedia()}}.
             </li>
             <li>
               If <code>constraints.</code>{{DisplayMediaStreamConstraints/selfBrowserSurface}} is
@@ -84,8 +86,8 @@
             <li>
               All other steps associated with {{MediaDevices/getDisplayMedia()}} should now be
               applied. If these steps culminate in the user agent presenting the user with a
-              selection of display surfaces, the user agent SHOULD present the current tab as the
-              most prominent option.
+              selection of <a data-cite="SCREEN-CAPTURE#dfn-display-surface">display surfaces</a>,
+              the user agent SHOULD present the current tab as the most prominent option.
             </li>
           </ol>
         </dd>

--- a/index.html
+++ b/index.html
@@ -65,28 +65,31 @@
         </dt>
         <dd>
           <p>
-            When {{MediaDevices/getDisplayMedia()}} is called, the user agent MUST run the following
-            steps:
+            When {{MediaDevices/getDisplayMedia()}} is called with <code>|constraints|</code> (a
+            dictionary), the user agent MUST run the following steps:
           </p>
           <ol>
             <li>
-              <p>Let <var>constraints</var> be the method's first argument.</p>
+              If <code>|constraints|.preferCurrentTab</code> is <code>false</code>, abort these
+              steps and continue instead with the
+              <a href="https://www.w3.org/TR/screen-capture/#dom-mediadevices-getdisplaymedia"
+                >getDisplayMedia algorithm</a
+              >.
             </li>
             <li>
-              If <code>constraints.preferCurrentTab</code> is <code>false</code>, abort these steps
-              and continue instead with the usual set of steps associated
-              {{MediaDevices/getDisplayMedia()}}.
-            </li>
-            <li>
-              If <code>constraints.</code>{{DisplayMediaStreamOptions/selfBrowserSurface}} is
+              If <code>|constraints|.</code>{{DisplayMediaStreamOptions/selfBrowserSurface}} is
               {{SelfCapturePreferenceEnum/"exclude"}}, return a promise [=reject|rejected=] with a
               newly [=exception/created=] {{TypeError}}.
             </li>
             <li>
-              All other steps associated with {{MediaDevices/getDisplayMedia()}} should now be
-              applied. If these steps culminate in the user agent presenting the user with a
-              selection of <a data-cite="SCREEN-CAPTURE#dfn-display-surface">display surfaces</a>,
-              the user agent SHOULD present the current tab as the most prominent option.
+              All other steps associated with
+              <a href="https://www.w3.org/TR/screen-capture/#dom-mediadevices-getdisplaymedia"
+                >getDisplayMedia algorithm</a
+              >
+              should now be applied. If these steps culminate in the user agent presenting the user
+              with a selection of
+              <a data-cite="SCREEN-CAPTURE#dfn-display-surface">display surfaces</a>, the user agent
+              SHOULD present the current tab as the most prominent option.
             </li>
           </ol>
         </dd>

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
               {{MediaDevices/getDisplayMedia()}}.
             </li>
             <li>
-              If <code>constraints.</code>{{DisplayMediaStreamConstraints/selfBrowserSurface}} is
+              If <code>constraints.</code>{{DisplayMediaStreamOptions/selfBrowserSurface}} is
               {{SelfCapturePreferenceEnum/"exclude"}}, return a promise <a>rejected</a>
               with a {{DOMException}} object whose {{DOMException/name}} attribute has the value
               {{InvalidStateError}}.

--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
           <dfn>preferCurrentTab</dfn>
         </dt>
         <dd>
+          <!-- TODO: Refactor the getDisplayMedia to more easily allow hooking into. -->
           <p>
             When {{MediaDevices/getDisplayMedia()}} is called with <code>|constraints|</code> (a
             dictionary), the user agent MUST run the following steps:

--- a/index.html
+++ b/index.html
@@ -65,10 +65,27 @@
         </dt>
         <dd>
           <p>
-            When {{MediaDevices/getDisplayMedia()}} is called, if <code>preferCurrentTab</code> is
-            <code>true</code>, the user agent SHOULD present the current tab as the most prominent
-            option. Otherwise, no such requirement is made.
+            When {{MediaDevices/getDisplayMedia()}} is called, the user agent MUST run the following
+            steps:
           </p>
+          <ol>
+            <li>
+              <p>Let <var>constraints</var> be the method's first argument.</p>
+            </li>
+            <li>
+              If <code>constraints.preferCurrentTab</code> is <code>false</code>, abort these steps.
+            </li>
+            <li>
+              If <code>constraints.</code>{{DisplayMediaStreamConstraints/selfBrowserSurface}} is
+              {{SelfCapturePreferenceEnum/"exclude"}}, return a promise <a>rejected</a>
+              with a {{DOMException}} object whose {{DOMException/name}} attribute has the value
+              {{InvalidStateError}}.
+            </li>
+            <li>
+              The user agent SHOULD present the current tab as the most prominent option. All other
+              steps associated with {{MediaDevices/getDisplayMedia()}} should now be applied.
+            </li>
+          </ol>
         </dd>
       </dl>
     </section>

--- a/index.html
+++ b/index.html
@@ -81,9 +81,10 @@
               with a {{DOMException}} object whose {{DOMException/name}} attribute has the value
               {{InvalidStateError}}.
             </li>
+            <li>The user agent SHOULD present the current tab as the most prominent option.</li>
             <li>
-              The user agent SHOULD present the current tab as the most prominent option. All other
-              steps associated with {{MediaDevices/getDisplayMedia()}} should now be applied.
+              All other steps associated with {{MediaDevices/getDisplayMedia()}} should now be
+              applied.
             </li>
           </ol>
         </dd>


### PR DESCRIPTION
1. Improve spec language.
2. Handle the nonsensical configuration of the app asking to both prefer as well as exclude the current tab. (This is newly possible following the introduction of [selfBrowserSurface](https://www.w3.org/TR/screen-capture/#dom-displaymediastreamconstraints-selfbrowsersurface).)